### PR TITLE
Update <title> to use the format ' .Title | .Site.Title '

### DIFF
--- a/themes/deliciousreverie/layouts/partials/header.html
+++ b/themes/deliciousreverie/layouts/partials/header.html
@@ -4,7 +4,7 @@
 	<meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
-	<title>{{ .Title }}</title>
+	<title>{{ with .Title }}{{ . }} | {{ end }}{{ .Site.Title }}</title>
 	{{ with .Site.Params.description }}<meta name="description" content="{{ . }}">{{ end }}
 	{{ with .Site.Params.author }}<meta name="author" content="{{ . }}">{{ end }}
 	<link rel="stylesheet" href="{{ .Site.BaseURL }}/css/deliciousreverie.min.css">


### PR DESCRIPTION
Updated the `<title>` to use the format `Title | Site.Title` in reference to issue #1 

I've jumped the gun a little and assumed you're happy with this format. I believe this is what you had on your Perch site, but could be mistaken ;)

This PR will give you this:

![image](https://cloud.githubusercontent.com/assets/3949335/26038434/42bd99bc-3900-11e7-960e-93f5b194d790.png)
